### PR TITLE
Add information to select TT in calculator

### DIFF
--- a/docs/EN/Getting-Started/Screenshots.md
+++ b/docs/EN/Getting-Started/Screenshots.md
@@ -47,6 +47,8 @@ SUPER BOLUS is where the basal insulin for the next two hours is added to the im
 
 **Section C:** shows the various elements that have been used to calculate the bolus. You can deselect any that you do not want to include but you normally wouldn't want to.
 
+Note: You have to select the TT box if you want loop to consider active temp targets. If box is not selected loop will use only your standard target no matter if a TT is defined or not.
+
 ## Insulin Profile
 
 ![Insulin Profile](../images/Screenshot_insulin_profile.png)


### PR DESCRIPTION
Had the problem that I was confused why loop did not use TT in calculation. Therefore I add what I learned from FB to the wiki.